### PR TITLE
add snowflake quickstart

### DIFF
--- a/quickstarts/snowflake/.gitignore
+++ b/quickstarts/snowflake/.gitignore
@@ -1,0 +1,23 @@
+# virtualenv
+.venv/
+
+# pyenv
+.python-version
+
+# python file
+__pycache__
+*.pyc
+.pytest_cache
+
+# MacOS
+.DS_Store
+
+# JetBrains IDE
+.idea/*
+!.idea/runConfigurations/
+
+# VSCode settings
+.vscode
+
+# Ascend builder output folder
+ascend-out/

--- a/quickstarts/snowflake/README.md
+++ b/quickstarts/snowflake/README.md
@@ -2,5 +2,5 @@
 
 Welcome to the Ascend Quickstart! This guide will help you get started with your Ascend platform.
 
-You can find [the documentation here](https://docs.ascend.io/getting-started/quickstart-fabric).
+You can find [the documentation here](https://docs.ascend.io/getting-started/quickstart-snowflake).
 

--- a/quickstarts/snowflake/ascend_project.yaml
+++ b/quickstarts/snowflake/ascend_project.yaml
@@ -1,0 +1,7 @@
+project:
+  name: fabric
+  connections: ["connections/"]
+  flows: ["flows/"]
+  profiles: ["profiles/"]
+  sources: ["src/"]
+  vaults: ["vaults/"]

--- a/quickstarts/snowflake/ascend_project.yaml
+++ b/quickstarts/snowflake/ascend_project.yaml
@@ -1,5 +1,5 @@
 project:
-  name: fabric
+  name: snowflake
   connections: ["connections/"]
   flows: ["flows/"]
   profiles: ["profiles/"]

--- a/quickstarts/snowflake/connections/local_files.yaml
+++ b/quickstarts/snowflake/connections/local_files.yaml
@@ -1,0 +1,3 @@
+connection:
+  local_file:
+    root: ./data

--- a/quickstarts/snowflake/connections/snowflake_data_plane.yaml
+++ b/quickstarts/snowflake/connections/snowflake_data_plane.yaml
@@ -1,0 +1,10 @@
+connection:
+  snowflake:
+    account: ${parameters.snowflake.account}
+    user: ${parameters.snowflake.user}
+    password: ${vaults.environment.snowflake-password}
+    database: ${parameters.snowflake.database}
+    schema: ${parameters.snowflake.schema}
+    warehouse: ${parameters.snowflake.warehouse}
+    role: ${parameters.snowflake.role}
+    create_schema_if_not_exists: true

--- a/quickstarts/snowflake/data/data.csv
+++ b/quickstarts/snowflake/data/data.csv
@@ -1,0 +1,4 @@
+string_col,num_col
+foo,1
+bar,2
+baz,5

--- a/quickstarts/snowflake/flows/quickstart/components/lake_reader.yaml
+++ b/quickstarts/snowflake/flows/quickstart/components/lake_reader.yaml
@@ -1,0 +1,15 @@
+component:
+  read:
+    connection: local_files
+    local_file:
+      path: /data.csv
+      parser:
+        csv:
+          has_header: true
+  tests:
+    columns:
+      string_col:
+        - not_null
+        - unique
+      num_col:
+        - not_null

--- a/quickstarts/snowflake/flows/quickstart/components/my_python_transform.py
+++ b/quickstarts/snowflake/flows/quickstart/components/my_python_transform.py
@@ -1,0 +1,9 @@
+from ibis import ir
+
+from ascend.resources import ref, transform
+
+
+@transform(inputs=[ref("lake_reader")])
+def my_python_transform(lake_reader: ir.Table, context) -> ir.Table:
+  # lake_reader is an Ibis Table object containing records from the lake_reader component
+  return lake_reader

--- a/quickstarts/snowflake/flows/quickstart/components/sample_sql_transform.sql.jinja
+++ b/quickstarts/snowflake/flows/quickstart/components/sample_sql_transform.sql.jinja
@@ -1,0 +1,3 @@
+-- a query that queries a table produced by the lake_reader component stored in data plane storage
+SELECT *
+FROM {{ ref('lake_reader') }}

--- a/quickstarts/snowflake/flows/quickstart/quickstart.yaml
+++ b/quickstarts/snowflake/flows/quickstart/quickstart.yaml
@@ -1,0 +1,2 @@
+flow:
+  version: 0.1.0

--- a/quickstarts/snowflake/profiles/dev.yaml
+++ b/quickstarts/snowflake/profiles/dev.yaml
@@ -1,0 +1,22 @@
+profile:
+  parameters:
+
+    snowflake:
+      # Snowflake account
+      # e.g. account: wvwohks-syb91821
+      account: <your-snowflake-account>
+
+      # adjust the values below if needed
+      user: ASCEND_ENV_DEV
+      database: ASCEND_ENV_DEV
+      schema: ASCEND_ENV_DEV
+      warehouse: ASCEND_ENV_DEV
+      role: ASCEND_ENV_DEV
+
+  defaults:
+    - kind: Flow
+      name:
+        regex: .*
+      spec:
+        data_plane:
+          connection_name: snowflake_data_plane


### PR DESCRIPTION
add snowflake quickstart based on fabric quickstart. also edits the fabric readme, keeping both fairly minimal while we stabilize the quickstarts/marquee project