### PR TITLE
remove gcp account from gs_lake connection

### DIFF
--- a/ottos-expeditions/projects/bigquery/connections/gs_lake.yaml
+++ b/ottos-expeditions/projects/bigquery/connections/gs_lake.yaml
@@ -1,5 +1,3 @@
 connection:
   gcs:
     root: gs://ascend-io-gcs-public
-    # TODO: update
-    project: ascend-io-cody


### PR DESCRIPTION
I believe I added this due to confusion with the build, thinking it was required. It does not seem required from my testing. We may want to move this data to another public bucket anyway, but should also remove this project name for now
