### PR TITLE
add ottos-expeditions workdir to GHA

### DIFF
--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   datagen:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ottos-expeditions
     steps:
       # checkout the repository
       - name: checkout


### PR DESCRIPTION
run the ottos-expedition GHA using the ottos-expedition directory as the working directory
