### PR TITLE
source python venv in GHA

### DIFF
--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -33,5 +33,7 @@ jobs:
       - run: just install
 
       # run datagen
-      - run: ottos-expeditions datagen --days 7
+      - run: |
+          . .venv/bin/activate
+          ottos-expeditions datagen --days 7
 


### PR DESCRIPTION
to fix the GHA, source the Python virtual environment before running the CLI
