### PR TITLE
update Otto's Expedition data nightly

### DIFF
--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -4,12 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"
-  on:
-    pull_request:
-      types: [opened, reopened]
-      paths:
-        - "ottos-expeditions/**"
-        - ".github/workflows/ottos-expeditions.yaml"
+  pull_request:
+    types: [opened, reopened]
+    paths:
+      - "ottos-expeditions/**"
+      - ".github/workflows/ottos-expeditions.yaml"
 
   # push:
   #   branches: ["main"]

--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -4,6 +4,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"
+  on:
+    pull_request:
+      types: [opened, reopened]
+      paths:
+        - "ottos-expeditions/**"
+        - ".github/workflows/ottos-expeditions.yaml"
+
   # push:
   #   branches: ["main"]
   #   paths:
@@ -16,6 +23,7 @@ concurrency:
 
 jobs:
   datagen:
+    if: ${{ github.event.label.name == 'run_datagen_on_pr' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -24,6 +32,15 @@ jobs:
       # checkout the repository
       - name: checkout
         uses: actions/checkout@v4
+
+      # setup gcloud
+      - id: 'GCP auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: 'GCP SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       # install Python and just and uv
       - uses: actions/setup-python@v4

--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       # setup gcloud
-      - id: 'GCP auth'
+      - name: 'GCP auth'
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'

--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "0 4 * * *"
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, synchronize, labeled]
     paths:
       - "ottos-expeditions/**"
       - ".github/workflows/ottos-expeditions.yaml"

--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: 'GCP auth'
         uses: 'google-github-actions/auth@v2'
         with:
+          project_id: ${{ vars.GCP_PROJECT_ID }}
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
       - name: 'GCP SDK'

--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -22,7 +22,10 @@ concurrency:
 
 jobs:
   datagen:
-    if: ${{ github.event.label.name == 'run_datagen_on_pr' }}
+    # to check if the event was labelling...
+    # if: ${{ github.event.label.name == 'run_datagen_on_pr' }}
+    # to check if the PR has the label...
+    if: contains(github.event.pull_request.labels.*.name, 'run_datagen_on_pr')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -17,8 +17,8 @@ on:
   #     - ".github/workflows/ottos-expeditions.yaml"
 
 concurrency:
-  group: "ottos-expeditions"
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   datagen:

--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -60,3 +60,4 @@ jobs:
           . .venv/bin/activate
           ottos-expeditions datagen --days 7
 
+      - run: just upload-gs

--- a/.github/workflows/ottos-expeditions.yaml
+++ b/.github/workflows/ottos-expeditions.yaml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "0 4 * * *"
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, labeled]
     paths:
       - "ottos-expeditions/**"
       - ".github/workflows/ottos-expeditions.yaml"


### PR DESCRIPTION
this PR updates the nightly Otto's Expedition GitHub Action to upload new synthetic data to the GCS bucket. the logic is:

- every night or on PRs with the `run_datagen_on_pr` label...
    - alternatively, we could run it on PRs only when given the label (and remove it as part of the action)
- generate the last 7 days of data
- `rsync` it to the bucket (generally overwriting the last 6 days of data)

steps taken:

- create service account
- give write permissions on GCS bucket to service account
- add service account secret JSON file as a GitHub action repo secret
- add GCP project ID as a GitHub action repo variable 

this may be fine as-is, or we might want more sophisitication. or just generate 1 day of data back, but we risk missing data if GitHub Actions don't run for whatever reason. also feature not a bug -- easier backfill demos? "the underlying data for the last 6 days changed, let's backfill and see the differences"